### PR TITLE
Windows: fix killSexpForward and killSexpBackward keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -405,13 +405,13 @@
             },
             {
                 "command": "paredit.killSexpForward",
-                "key": "cmd+shift+backspace",
+                "key": "ctrl+shift+backspace",
                 "mac": "cmd+shift+backspace",
                 "when": "editorTextFocus"
             },
             {
                 "command": "paredit.killSexpBackward",
-                "key": "cmd+backspace",
+                "key": "ctrl+backspace",
                 "mac": "cmd+backspace",
                 "when": "editorTextFocus"
             },


### PR DESCRIPTION
Hi there,

Thanks for maintaining this extension. I noticed on my Windows machine the very important `killSexpForward` and `killSexpBackward` commands weren't working. I think there was a copy/paste problem whenever someone did the key mapping there, because the `cmd` key doesn't work on Windows -- at least as far as I can tell.

This simple fix resolves the problem for me and will hopefully be helpful to other Windows users.