### PR TITLE
spliceSexpKillForward/Backward: swap key bindings to match README

### DIFF
--- a/package.json
+++ b/package.json
@@ -417,14 +417,14 @@
             },
             {
                 "command": "paredit.spliceSexpKillForward",
-                "key": "ctrl+alt+up",
-                "mac": "ctrl+alt+up",
+                "key": "ctrl+alt+down",
+                "mac": "ctrl+alt+down",
                 "when": "editorTextFocus"
             },
             {
                 "command": "paredit.spliceSexpKillBackward",
-                "key": "ctrl+alt+down",
-                "mac": "ctrl+alt+down",
+                "key": "ctrl+alt+up",
+                "mac": "ctrl+alt+up",
                 "when": "editorTextFocus"
             },
             {


### PR DESCRIPTION
Looks like this may have just been an integration error: the common standard for these functions is UP to kill backwards (moving "up" the tree), and DOWN to kill forwards. The README documents these correctly, but the package.json file has them swapped.