### PR TITLE
Add strict mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ ctrl+alt+{         | Wrap Around {}
 ctrl+alt+i         | Indent
 ---                | Transpose
 
+#### Strict mode (enabled by default)
+
+In strict mode, the backspace and delete keys won't let you remove parentheses or brackets so they become unbalanced. To force a delete anyway use these commands:
+
+Default keybinding | Action
+------------------ | ------
+ctrl+alt+backspace | Force Delete Backward
+ctrl+alt+delete    | Force Delete Forward
+
+Strict mode can be switched off by by configuring `calva.paredit.defaultKeyMap` to `original` instead of `strict`.
+
 ### Copying/Yanking
 
 Default keybinding | Action

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
                     "calva.paredit.defaultKeyMap": {
                         "type": "string",
                         "description": "The default keymap to use for bindings when there is no custom binding.",
-                        "default": "original",
+                        "default": "strict",
                         "enum": [
                             "original",
                             "strict",

--- a/package.json
+++ b/package.json
@@ -464,6 +464,16 @@
                 "command": "paredit.deleteBackward",
                 "key": "backspace",
                 "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == strict && editorTextFocus && !editorReadOnly"
+            },
+            {
+                "command": "deleteRight",
+                "key": "ctrl+alt+delete",
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == strict && editorTextFocus && !editorReadOnly"
+            },
+            {
+                "command": "deleteLeft",
+                "key": "ctrl+alt+backspace",
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == strict && editorTextFocus && !editorReadOnly"
             }
         ]
     },

--- a/package.json
+++ b/package.json
@@ -63,6 +63,8 @@
         "onCommand:paredit.killSexpBackward",
         "onCommand:paredit.spliceSexpKillForward",
         "onCommand:paredit.spliceSexpKillBackward",
+        "onCommand:paredit.deleteForward",
+        "onCommand:paredit.deleteBackward",
         "onCommand:paredit.wrapAroundParens",
         "onCommand:paredit.wrapAroundSquare",
         "onCommand:paredit.wrapAroundCurly",
@@ -82,6 +84,7 @@
                         "default": "original",
                         "enum": [
                             "original",
+                            "strict",
                             "none"
                         ],
                         "scope": "window"
@@ -247,6 +250,16 @@
             },
             {
                 "category": "Paredit",
+                "command": "paredit.deleteForward",
+                "title": "Delete Forward"
+            },
+            {
+                "category": "Paredit",
+                "command": "paredit.deleteBackward",
+                "title": "Delete Backward"
+            },
+            {
+                "category": "Paredit",
                 "command": "paredit.wrapAroundParens",
                 "title": "Wrap Around ()"
             },
@@ -275,172 +288,182 @@
             {
                 "command": "paredit.forwardSexp",
                 "key": "ctrl+right",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == original && editorTextFocus && !editorReadOnly"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap =~ /original|strict/ && editorTextFocus && !editorReadOnly"
             },
             {
                 "command": "paredit.backwardSexp",
                 "key": "ctrl+left",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == original && editorTextFocus && !editorReadOnly"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap =~ /original|strict/ && editorTextFocus && !editorReadOnly"
             },
             {
                 "command": "paredit.forwardDownSexp",
                 "key": "ctrl+down",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == original && editorTextFocus && !editorReadOnly"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap =~ /original|strict/ && editorTextFocus && !editorReadOnly"
             },
             {
                 "command": "paredit.backwardUpSexp",
                 "key": "ctrl+up",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == original && editorTextFocus && !editorReadOnly"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap =~ /original|strict/ && editorTextFocus && !editorReadOnly"
             },
             {
                 "command": "paredit.closeList",
                 "key": "ctrl+alt+right",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == original && editorTextFocus && !editorReadOnly"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap =~ /original|strict/ && editorTextFocus && !editorReadOnly"
             },
             {
                 "command": "paredit.rangeForDefun",
                 "key": "ctrl+alt+w space",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == original && editorTextFocus && !editorReadOnly"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap =~ /original|strict/ && editorTextFocus && !editorReadOnly"
             },
             {
                 "command": "paredit.sexpRangeExpansion",
                 "key": "ctrl+w",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == original && editorTextFocus && !editorReadOnly"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap =~ /original|strict/ && editorTextFocus && !editorReadOnly"
             },
             {
                 "command": "paredit.sexpRangeContraction",
                 "key": "ctrl+shift+w",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == original && editorTextFocus && !editorReadOnly"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap =~ /original|strict/ && editorTextFocus && !editorReadOnly"
             },
             {
                 "command": "paredit.yankForwardSexp",
                 "key": "ctrl+alt+c ctrl+right",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == original && editorTextFocus && !editorReadOnly"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap =~ /original|strict/ && editorTextFocus && !editorReadOnly"
             },
             {
                 "command": "paredit.yankBackwardSexp",
                 "key": "ctrl+alt+c ctrl+left",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == original && editorTextFocus && !editorReadOnly"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap =~ /original|strict/ && editorTextFocus && !editorReadOnly"
             },
             {
                 "command": "paredit.yankForwardDownSexp",
                 "key": "ctrl+alt+c ctrl+down",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == original && editorTextFocus && !editorReadOnly"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap =~ /original|strict/ && editorTextFocus && !editorReadOnly"
             },
             {
                 "command": "paredit.yankBackwardUpSexp",
                 "key": "ctrl+alt+c ctrl+up",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == original && editorTextFocus && !editorReadOnly"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap =~ /original|strict/ && editorTextFocus && !editorReadOnly"
             },
             {
                 "command": "paredit.yankCloseList",
                 "key": "ctrl+alt+c ctrl+alt+right",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == original && editorTextFocus && !editorReadOnly"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap =~ /original|strict/ && editorTextFocus && !editorReadOnly"
             },
             {
                 "command": "paredit.yankRangeForDefun",
                 "key": "ctrl+alt+c space",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == original && editorTextFocus && !editorReadOnly"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap =~ /original|strict/ && editorTextFocus && !editorReadOnly"
             },
             {
                 "command": "paredit.cutForwardSexp",
                 "key": "ctrl+alt+x ccutright",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == original && editorTextFocus && !editorReadOnly"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap =~ /original|strict/ && editorTextFocus && !editorReadOnly"
             },
             {
                 "command": "paredit.cutBackwardSexp",
                 "key": "ctrl+alt+x ccutleft",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == original && editorTextFocus && !editorReadOnly"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap =~ /original|strict/ && editorTextFocus && !editorReadOnly"
             },
             {
                 "command": "paredit.cutForwardDownSexp",
                 "key": "ctrl+alt+x ccutdown",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == original && editorTextFocus && !editorReadOnly"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap =~ /original|strict/ && editorTextFocus && !editorReadOnly"
             },
             {
                 "command": "paredit.cutBackwardUpSexp",
                 "key": "ctrl+alt+x ccutup",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == original && editorTextFocus && !editorReadOnly"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap =~ /original|strict/ && editorTextFocus && !editorReadOnly"
             },
             {
                 "command": "paredit.cutCloseList",
                 "key": "ctrl+alt+x ctrl+alt+right",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == original && editorTextFocus && !editorReadOnly"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap =~ /original|strict/ && editorTextFocus && !editorReadOnly"
             },
             {
                 "command": "paredit.cutRangeForDefun",
                 "key": "ctrl+alt+x space",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == original && editorTextFocus && !editorReadOnly"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap =~ /original|strict/ && editorTextFocus && !editorReadOnly"
             },
             {
                 "command": "paredit.slurpSexpForward",
                 "key": "ctrl+alt+.",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == original && editorTextFocus && !editorReadOnly"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap =~ /original|strict/ && editorTextFocus && !editorReadOnly"
             },
             {
                 "command": "paredit.slurpSexpBackward",
                 "key": "ctrl+alt+shift+.",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == original && editorTextFocus && !editorReadOnly"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap =~ /original|strict/ && editorTextFocus && !editorReadOnly"
             },
             {
                 "command": "paredit.barfSexpForward",
                 "key": "ctrl+alt+,",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == original && editorTextFocus && !editorReadOnly"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap =~ /original|strict/ && editorTextFocus && !editorReadOnly"
             },
             {
                 "command": "paredit.barfSexpBackward",
                 "key": "ctrl+alt+shift+,",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == original && editorTextFocus && !editorReadOnly"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap =~ /original|strict/ && editorTextFocus && !editorReadOnly"
             },
             {
                 "command": "paredit.spliceSexp",
                 "key": "ctrl+alt+s",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == original && editorTextFocus && !editorReadOnly"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap =~ /original|strict/ && editorTextFocus && !editorReadOnly"
             },
             {
                 "command": "paredit.splitSexp",
                 "key": "ctrl+alt+/",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == original && editorTextFocus && !editorReadOnly"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap =~ /original|strict/ && editorTextFocus && !editorReadOnly"
             },
             {
                 "command": "paredit.killSexpForward",
                 "key": "ctrl+shift+backspace",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == original && editorTextFocus && !editorReadOnly"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap =~ /original|strict/ && editorTextFocus && !editorReadOnly"
             },
             {
                 "command": "paredit.killSexpBackward",
                 "key": "ctrl+backspace",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == original && editorTextFocus && !editorReadOnly"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap =~ /original|strict/ && editorTextFocus && !editorReadOnly"
             },
             {
                 "command": "paredit.spliceSexpKillForward",
                 "key": "ctrl+alt+down",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == original && editorTextFocus && !editorReadOnly"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap =~ /original|strict/ && editorTextFocus && !editorReadOnly"
             },
             {
                 "command": "paredit.spliceSexpKillBackward",
                 "key": "ctrl+alt+up",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == original && editorTextFocus && !editorReadOnly"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap =~ /original|strict/ && editorTextFocus && !editorReadOnly"
             },
             {
                 "command": "paredit.wrapAroundParens",
                 "key": "ctrl+alt+shift+9",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == original && editorTextFocus && !editorReadOnly"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap =~ /original|strict/ && editorTextFocus && !editorReadOnly"
             },
             {
                 "command": "paredit.wrapAroundSquare",
                 "key": "ctrl+alt+[",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == original && editorTextFocus && !editorReadOnly"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap =~ /original|strict/ && editorTextFocus && !editorReadOnly"
             },
             {
                 "command": "paredit.wrapAroundCurly",
                 "key": "ctrl+alt+shift+[",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == original && editorTextFocus && !editorReadOnly"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap =~ /original|strict/ && editorTextFocus && !editorReadOnly"
             },
             {
                 "command": "paredit.indentRange",
                 "key": "ctrl+alt+i",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == original && editorTextFocus && !editorReadOnly"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap =~ /original|strict/ && editorTextFocus && !editorReadOnly"
+            },
+            {
+                "command": "paredit.deleteForward",
+                "key": "delete",
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == strict && editorTextFocus && !editorReadOnly"
+            },
+            {
+                "command": "paredit.deleteBackward",
+                "key": "backspace",
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == strict && editorTextFocus && !editorReadOnly"
             }
         ]
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -125,6 +125,8 @@ const pareditCommands: [string, Function][] = [
     ['paredit.killSexpBackward', edit(paredit.editor.killSexp, { 'backward': true })],
     ['paredit.spliceSexpKillForward', edit(paredit.editor.spliceSexpKill, { 'backward': false })],
     ['paredit.spliceSexpKillBackward', edit(paredit.editor.spliceSexpKill, { 'backward': true })],
+    ['paredit.deleteForward', edit(paredit.editor.delete, { 'backward': false })],
+    ['paredit.deleteBackward', edit(paredit.editor.delete, { 'backward': true })],
     ['paredit.wrapAroundParens', edit(paredit.editor.wrapAround, '(', ')')],
     ['paredit.wrapAroundSquare', edit(paredit.editor.wrapAround, '[', ']')],
     ['paredit.wrapAroundCurly', edit(paredit.editor.wrapAround, '{', '}')],


### PR DESCRIPTION
This PR exposes paredit.js' forward and backward delete (which won't let you delete matched parentheses and brackets) and adds a "strict" keymap in addition to the existing "original" where `backspace` is bound to backward delete and `delete` is bound to forward delete.

Closes #4 