### PR TITLE
Fix deleting selections in strict mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -460,12 +460,12 @@
                 "command": "paredit.deleteForward",
                 "key": "delete",
                 "mac": "shift+backspace",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == strict && editorTextFocus && !editorReadOnly && !editorHasSelection && !editorHasMultipleSelections"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == strict && editorTextFocus && !editorReadOnly && !editorHasMultipleSelections"
             },
             {
                 "command": "paredit.deleteBackward",
                 "key": "backspace",
-                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == strict && editorTextFocus && !editorReadOnly && !editorHasSelection && !editorHasMultipleSelections"
+                "when": "editorLangId =~ /clojure|scheme|lisp/ && paredit:keyMap == strict && editorTextFocus && !editorReadOnly && !editorHasMultipleSelections"
             },
             {
                 "command": "deleteRight",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -86,7 +86,6 @@ const edit = (fn, ...args) =>
 const editWithEndIdx = (fn, args) =>
     ({ textEditor, src, ast, selection }) => {
         let res = fn(ast, src, selection.start, { ...args, endIdx: selection.end });
-        console.log("RES", res);
         if (res)
             if (res.changes.length > 0) {
                 let cmd = utils.commands(res),


### PR DESCRIPTION
Fixes so that strict mode deletion works when text is selected (but the other two points in this comment https://github.com/BetterThanTomorrow/calva-paredit/issues/14#issuecomment-433912461 are still unsolved)

The thing missing was sending endIdx to the paredit delete function.

Right now the edit function is just copy-pasted and modified, I'll see if I can refactor it in a nicer way  later today or tomorrow (or feel free to do so yourself if you want to merge quickly), but wanted to share what I found so far if it can be of any help.